### PR TITLE
chore(deps): update FluentIcons and FreeSql versions

### DIFF
--- a/src/Polymerium.App/Polymerium.App.csproj
+++ b/src/Polymerium.App/Polymerium.App.csproj
@@ -19,8 +19,8 @@
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
         <PackageReference Include="CsvHelper" Version="33.1.0"/>
         <PackageReference Include="DynamicData" Version="9.4.1"/>
-        <PackageReference Include="FluentIcons.Avalonia" Version="1.1.303-ci"/>
-        <PackageReference Include="FreeSql.Provider.SqliteCore" Version="3.5.207"/>
+        <PackageReference Include="FluentIcons.Avalonia" Version="1.1.303" />
+        <PackageReference Include="FreeSql.Provider.SqliteCore" Version="3.5.208" />
         <PackageReference Include="Humanizer" Version="3.0.0-beta.96"/>
         <PackageReference Include="IconPacks.Avalonia.Lucide" Version="1.0.0"/>
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"/>


### PR DESCRIPTION
Update FluentIcons.Avalonia from 1.1.303-ci to 1.1.303 and FreeSql.Provider.SqliteCore from 3.5.207 to 3.5.208 to use stable and latest package versions, improving dependency stability and potentially fixing bugs.