### PR TITLE
fix: 更新 Linux 端 SkiaSharp 版本

### DIFF
--- a/src/Polymerium.Avalonia/Polymerium.Avalonia.csproj
+++ b/src/Polymerium.Avalonia/Polymerium.Avalonia.csproj
@@ -59,6 +59,7 @@
         <PackageReference Include="NeoSmart.Caching.Sqlite.AspNetCore" Version="9.0.1" />
         <PackageReference Include="Semver" Version="3.0.0" />
         <PackageReference Include="SkiaSharp" Version="4.148.0" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.148.0" />
         <PackageReference Include="AsyncImageLoader.Avalonia" Version="3.8.0" />
         <PackageReference Include="Sentry" Version="6.6.0" />
         <PackageReference Include="Sentry.Profiling" Version="6.6.0" />


### PR DESCRIPTION
SkiaSharp 忘了声明 Linux 端包版本，把 AppImage 炸了