### PR TITLE
feat(dashboard): add auto-scroll toggle to the instance log view

### DIFF
--- a/src/Polymerium.Avalonia/PageModels/InstanceDashboardPageModel.cs
+++ b/src/Polymerium.Avalonia/PageModels/InstanceDashboardPageModel.cs
@@ -120,8 +120,6 @@ public partial class InstanceDashboardPageModel(
 
     partial void OnIsFilterErrorChanged(bool value) => SetupView();
 
-    // 日志自动跟随开关：默认开启（"默认是滚动状态"）。跟随逻辑见 InstanceDashboardPage 的 code-behind。
-    // 放在模型上而非控件上，与 IsFilterInformation 等 UI 开关保持一致，切换按钮可直接绑定。
     [ObservableProperty]
     public partial bool IsAutoScroll { get; set; } = true;
 

--- a/src/Polymerium.Avalonia/PageModels/InstanceDashboardPageModel.cs
+++ b/src/Polymerium.Avalonia/PageModels/InstanceDashboardPageModel.cs
@@ -121,9 +121,6 @@ public partial class InstanceDashboardPageModel(
     partial void OnIsFilterErrorChanged(bool value) => SetupView();
 
     [ObservableProperty]
-    public partial bool IsAutoScroll { get; set; } = true;
-
-    [ObservableProperty]
     public partial IList<ScrapModel>? LogCollection { get; set; }
 
     [ObservableProperty]

--- a/src/Polymerium.Avalonia/PageModels/InstanceDashboardPageModel.cs
+++ b/src/Polymerium.Avalonia/PageModels/InstanceDashboardPageModel.cs
@@ -120,6 +120,11 @@ public partial class InstanceDashboardPageModel(
 
     partial void OnIsFilterErrorChanged(bool value) => SetupView();
 
+    // 日志自动跟随开关：默认开启（"默认是滚动状态"）。跟随逻辑见 InstanceDashboardPage 的 code-behind。
+    // 放在模型上而非控件上，与 IsFilterInformation 等 UI 开关保持一致，切换按钮可直接绑定。
+    [ObservableProperty]
+    public partial bool IsAutoScroll { get; set; } = true;
+
     [ObservableProperty]
     public partial IList<ScrapModel>? LogCollection { get; set; }
 

--- a/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml
+++ b/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml
@@ -516,7 +516,7 @@
                         <!--  自动跟随开关：向上滚动离开底部时由 code-behind 自动取消勾选  -->
                         <ToggleButton
                             Classes="Small"
-                            IsChecked="{Binding IsAutoScroll, Mode=TwoWay}"
+                            IsChecked="{Binding $parent[app:InstanceDashboardPage].IsAutoScroll, Mode=TwoWay}"
                             ToolTip.Tip="{x:Static lang:Resources.InstanceDashboardPage_AutoScrollToolTipText}">
                             <ToggleButton.Styles>
                                 <Style Selector="ToggleButton:checked">
@@ -540,7 +540,9 @@
                         <ScrollViewer
                             x:Name="LogScroller"
                             HorizontalScrollBarVisibility="Auto">
-                            <ItemsControl ItemsSource="{Binding FilteredLogCollection}">
+                            <ItemsControl
+                                x:Name="LogList"
+                                ItemsSource="{Binding FilteredLogCollection}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <VirtualizingStackPanel />

--- a/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml
+++ b/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml
@@ -93,9 +93,7 @@
                         </TextBlock>
                     </Border>
                 </InlineUIContainer>
-                <Run
-                    FontFamily="Cascadia Code, Consolas, monospace"
-                    Text="{Binding Message}" />
+                <Run Text="{Binding Message}" />
             </TextBlock>
         </DataTemplate>
     </app:Subpage.Resources>
@@ -515,13 +513,12 @@
                             </StackPanel>
                         </ToggleButton>
                         <husk:Divider Orientation="Vertical" />
-                        <!--  自动滚动开关：默认选中。两种取消途径——点击取消，或向上滚动离开底部时由 code-behind 自动取消  -->
+                        <!--  自动跟随开关：向上滚动离开底部时由 code-behind 自动取消勾选  -->
                         <ToggleButton
                             Classes="Small"
                             IsChecked="{Binding IsAutoScroll, Mode=TwoWay}"
                             ToolTip.Tip="{x:Static lang:Resources.InstanceDashboardPage_AutoScrollToolTipText}">
                             <ToggleButton.Styles>
-                                <!--  选中态使用强调色，与左侧级别过滤开关的视觉语言一致，让跟随状态一目了然  -->
                                 <Style Selector="ToggleButton:checked">
                                     <Setter Property="Background" Value="{StaticResource ControlAccentTranslucentHalfBackgroundBrush}" />
                                     <Setter Property="Foreground" Value="{StaticResource ControlAccentForegroundBrush}" />

--- a/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml
+++ b/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml
@@ -93,7 +93,9 @@
                         </TextBlock>
                     </Border>
                 </InlineUIContainer>
-                <Run Text="{Binding Message}" />
+                <Run
+                    FontFamily="Cascadia Code, Consolas, monospace"
+                    Text="{Binding Message}" />
             </TextBlock>
         </DataTemplate>
     </app:Subpage.Resources>
@@ -512,6 +514,23 @@
                                 <TextBlock Text="{x:Static lang:Resources.InstanceDashboardPage_FilterErrorText}" />
                             </StackPanel>
                         </ToggleButton>
+                        <husk:Divider Orientation="Vertical" />
+                        <!--  自动滚动开关：默认选中。两种取消途径——点击取消，或向上滚动离开底部时由 code-behind 自动取消  -->
+                        <ToggleButton
+                            Classes="Small"
+                            IsChecked="{Binding IsAutoScroll, Mode=TwoWay}"
+                            ToolTip.Tip="{x:Static lang:Resources.InstanceDashboardPage_AutoScrollToolTipText}">
+                            <ToggleButton.Styles>
+                                <!--  选中态使用强调色，与左侧级别过滤开关的视觉语言一致，让跟随状态一目了然  -->
+                                <Style Selector="ToggleButton:checked">
+                                    <Setter Property="Background" Value="{StaticResource ControlAccentTranslucentHalfBackgroundBrush}" />
+                                    <Setter Property="Foreground" Value="{StaticResource ControlAccentForegroundBrush}" />
+                                </Style>
+                            </ToggleButton.Styles>
+                            <fi:SymbolIcon
+                                FontSize="{StaticResource LargeFontSize}"
+                                Symbol="TextBoxAlignBottom" />
+                        </ToggleButton>
                     </StackPanel>
                 </Grid>
 
@@ -521,7 +540,9 @@
                 <Panel Grid.Row="2">
                     <app:EmptyContainer IsEmpty="{Binding FilteredLogCollection.Count, Converter={x:Static husk:NumberConverters.IsZero}, FallbackValue={x:True}}">
                         <!--  日志列表  -->
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto">
+                        <ScrollViewer
+                            x:Name="LogScroller"
+                            HorizontalScrollBarVisibility="Auto">
                             <ItemsControl ItemsSource="{Binding FilteredLogCollection}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>

--- a/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml.cs
+++ b/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml.cs
@@ -14,30 +14,23 @@ public partial class InstanceDashboardPage : Subpage
 {
     private InstanceDashboardPageModel? _model;
 
-    // 当前正在订阅 CollectionChanged 的视图；FilteredLogCollection 会被重新赋值，
-    // 因此需要跟踪旧视图以便解绑，避免事件泄漏到已 Dispose 的视图上。
+    // FilteredLogCollection 在切换日志源时会被重新赋值（旧视图已 Dispose），
+    // 故需跟踪当前订阅的视图以便换绑时解绑，避免向已 Dispose 的视图挂事件。
     private NotifyCollectionChangedSynchronizedViewList<ScrapModel>? _subscribedView;
 
     public InstanceDashboardPage()
     {
         InitializeComponent();
-        // DataContext 由 activator 在进入视觉树时设置，必须等它到达后才能挂到模型上。
         DataContextChanged += OnDataContextChanged;
-        // 直接订阅日志 ScrollViewer 本身（而不是在页面级 AddHandler），
-        // 因为底部检测需要读取它的 Offset / ScrollBarMaximum。
         LogScroller.ScrollChanged += OnLogScrollChanged;
+        // DetachedFromVisualTree 在页面离开视觉树（导航离开）时触发，参数类型由事件推断，
+        // 故用 lambda 订阅而不直接引用 VisualTreeAttachmentEventArgs 的命名空间。
+        DetachedFromVisualTree += (_, _) => DetachSubscriptions();
     }
 
-    // 每次导航都会由 activator 创建全新的页面与模型；DataContext 变化时解绑旧模型、挂上新模型。
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
-        if (_model != null)
-        {
-            _model.PropertyChanged -= OnModelPropertyChanged;
-            _model = null;
-        }
-
-        Subscribe(null);
+        DetachSubscriptions();
 
         if (DataContext is InstanceDashboardPageModel model)
         {
@@ -47,15 +40,25 @@ public partial class InstanceDashboardPage : Subpage
         }
     }
 
+    // NOTE: 页面离开视觉树时必须解绑。实时源视图来自 scrapService 的共享缓冲，
+    //  其生命周期长于本页，不清理会让已 detach 的页面被缓冲间接保活并持续接收日志事件。
+    private void DetachSubscriptions()
+    {
+        if (_model != null)
+        {
+            _model.PropertyChanged -= OnModelPropertyChanged;
+            _model = null;
+        }
+
+        Subscribe(null);
+    }
+
     private void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // UpdateLogSource 会在切换日志源/启动/结束时重新赋值 FilteredLogCollection（旧视图已 Dispose），
-        // 这里必须跟着换绑 CollectionChanged，否则新视图的新增日志不会触发跟随滚动。
         if (e.PropertyName == nameof(InstanceDashboardPageModel.FilteredLogCollection))
         {
             Subscribe(_model?.FilteredLogCollection);
         }
-        // 用户点击切换按钮重新开启跟随时，无论当前在何处都应立刻跳到底部。
         else if (e.PropertyName == nameof(InstanceDashboardPageModel.IsAutoScroll) && _model?.IsAutoScroll == true)
         {
             Dispatcher.UIThread.Post(LogScroller.ScrollToEnd);
@@ -78,8 +81,8 @@ public partial class InstanceDashboardPage : Subpage
         if (view != null)
         {
             view.CollectionChanged += OnCollectionChanged;
-            // 视图刚就位时钉一次到底部：文件日志源是一次性整体载入的，可能不会再有 Add 事件，
-            // 而实时源在 OnInitializeAsync 挂载时缓冲可能已非空；Post 延迟到布局完成后执行。
+            // 文件源一次性载入后不再有 Add 事件，实时源挂载时缓冲可能已非空，
+            // 故换绑时先钉一次到底部；Post 等面板重算 extent 后再滚动。
             Dispatcher.UIThread.Post(() =>
             {
                 if (_model?.IsAutoScroll == true)
@@ -92,8 +95,7 @@ public partial class InstanceDashboardPage : Subpage
 
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        // Reset 也触发跟随：过滤开关/搜索变化时视图会整体重建，跟随开启时应保持钉底；
-        // 环形缓冲满时淘汰头部也会以 Reset/Add 形式体现，与 toast 的既有行为保持一致。
+        // Reset 覆盖过滤/搜索变化导致的视图整体重建，跟随开启时同样保持钉底。
         if (e.Action is not (NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Reset))
         {
             return;
@@ -101,15 +103,14 @@ public partial class InstanceDashboardPage : Subpage
 
         if (_model?.IsAutoScroll == true)
         {
-            // Post 而非同步调用：集合已变化但 VirtualizingStackPanel 的 extent 尚未重新布局，
-            // 立即 ScrollToEnd 会停在旧的底部；延迟到消息队列尾部执行才能拿到最新 extent。
+            // 集合已变但 VirtualizingStackPanel 尚未重算 extent，同步 ScrollToEnd 会停在旧底部，故延后执行。
             Dispatcher.UIThread.Post(LogScroller.ScrollToEnd);
         }
     }
 
-    // NOTE: 用 OffsetDelta 的符号而非仅位置判断，是关键不直观点——
-    // 跟随开启时新日志使 extent 增长，ScrollChanged 会因 extent 变化触发，但 OffsetDelta.Y 为 0；
-    // 若仅看"是否在底部"，该事件会误判为"离开底部"而关闭跟随。因此只在用户主动滚动（Delta 非零）时切换状态。
+    // NOTE: 用 OffsetDelta 的符号而非仅位置判断，是关键不直观点。
+    //  跟随开启时新日志使 extent 增长，ScrollChanged 会因 extent 变化再次触发，但 OffsetDelta.Y 为 0；
+    //  若只看「是否在底部」会把这次事件误判为「离开底部」而错误关闭跟随，故仅在用户主动滚动（Delta 非零）时切换。
     private void OnLogScrollChanged(object? sender, ScrollChangedEventArgs e)
     {
         if (_model == null)
@@ -120,12 +121,10 @@ public partial class InstanceDashboardPage : Subpage
         var atBottom = LogScroller.Viewport.Height > 0 && LogScroller.Offset.Y >= LogScroller.ScrollBarMaximum.Y - 0.5d;
         if (e.OffsetDelta.Y < 0 && !atBottom)
         {
-            // 用户向上滚动离开底部：说明在回看历史日志，停止跟随（按钮随之取消勾选）。
             _model.IsAutoScroll = false;
         }
         else if (e.OffsetDelta.Y > 0 && atBottom)
         {
-            // 用户主动滚回到底部：恢复跟随，对应"滚动条在最下方时持续滚动到最新日志"。
             _model.IsAutoScroll = true;
         }
     }

--- a/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml.cs
+++ b/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml.cs
@@ -1,99 +1,55 @@
-using System;
 using System.Collections.Specialized;
-using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using ObservableCollections;
 using Polymerium.Avalonia.Controls;
-using Polymerium.Avalonia.Models;
-using Polymerium.Avalonia.PageModels;
 
 namespace Polymerium.Avalonia.Pages;
 
 public partial class InstanceDashboardPage : Subpage
 {
-    private InstanceDashboardPageModel? _model;
+    public static readonly DirectProperty<InstanceDashboardPage, bool> IsAutoScrollProperty =
+        AvaloniaProperty.RegisterDirect<InstanceDashboardPage, bool>(
+            nameof(IsAutoScroll),
+            o => o.IsAutoScroll,
+            (o, v) => o.IsAutoScroll = v,
+            true);
 
-    // FilteredLogCollection 在切换日志源时会被重新赋值（旧视图已 Dispose），
-    // 故需跟踪当前订阅的视图以便换绑时解绑，避免向已 Dispose 的视图挂事件。
-    private NotifyCollectionChangedSynchronizedViewList<ScrapModel>? _subscribedView;
+    public bool IsAutoScroll
+    {
+        get;
+        set => SetAndRaise(IsAutoScrollProperty, ref field, value);
+    } = true;
+
+    private bool _scrollPending;   // 钉底请求合并标志，配合 RequestScrollToEnd 做节流
+
+    private int _disableDebounce;  // 关闭跟随的滞回计数
 
     public InstanceDashboardPage()
     {
         InitializeComponent();
-        DataContextChanged += OnDataContextChanged;
+        ((INotifyCollectionChanged)LogList.Items).CollectionChanged += OnItemsChanged;
         LogScroller.ScrollChanged += OnLogScrollChanged;
-        // DetachedFromVisualTree 在页面离开视觉树（导航离开）时触发，参数类型由事件推断，
-        // 故用 lambda 订阅而不直接引用 VisualTreeAttachmentEventArgs 的命名空间。
-        DetachedFromVisualTree += (_, _) => DetachSubscriptions();
     }
 
-    private void OnDataContextChanged(object? sender, EventArgs e)
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        DetachSubscriptions();
+        base.OnPropertyChanged(change);
 
-        if (DataContext is InstanceDashboardPageModel model)
+        if (change.Property == IsAutoScrollProperty && change.NewValue is true)
         {
-            _model = model;
-            model.PropertyChanged += OnModelPropertyChanged;
-            Subscribe(model.FilteredLogCollection);
+            RequestScrollToEnd();
         }
     }
 
-    // NOTE: 页面离开视觉树时必须解绑。实时源视图来自 scrapService 的共享缓冲，
-    //  其生命周期长于本页，不清理会让已 detach 的页面被缓冲间接保活并持续接收日志事件。
-    private void DetachSubscriptions()
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
-        if (_model != null)
-        {
-            _model.PropertyChanged -= OnModelPropertyChanged;
-            _model = null;
-        }
-
-        Subscribe(null);
+        ((INotifyCollectionChanged)LogList.Items).CollectionChanged -= OnItemsChanged;
+        LogScroller.ScrollChanged -= OnLogScrollChanged;
+        base.OnDetachedFromVisualTree(e);
     }
 
-    private void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(InstanceDashboardPageModel.FilteredLogCollection))
-        {
-            Subscribe(_model?.FilteredLogCollection);
-        }
-        else if (e.PropertyName == nameof(InstanceDashboardPageModel.IsAutoScroll) && _model?.IsAutoScroll == true)
-        {
-            Dispatcher.UIThread.Post(LogScroller.ScrollToEnd);
-        }
-    }
-
-    private void Subscribe(NotifyCollectionChangedSynchronizedViewList<ScrapModel>? view)
-    {
-        if (_subscribedView == view)
-        {
-            return;
-        }
-
-        if (_subscribedView != null)
-        {
-            _subscribedView.CollectionChanged -= OnCollectionChanged;
-        }
-
-        _subscribedView = view;
-        if (view != null)
-        {
-            view.CollectionChanged += OnCollectionChanged;
-            // 文件源一次性载入后不再有 Add 事件，实时源挂载时缓冲可能已非空，
-            // 故换绑时先钉一次到底部；Post 等面板重算 extent 后再滚动。
-            Dispatcher.UIThread.Post(() =>
-            {
-                if (_model?.IsAutoScroll == true)
-                {
-                    LogScroller.ScrollToEnd();
-                }
-            });
-        }
-    }
-
-    private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    private void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         // Reset 覆盖过滤/搜索变化导致的视图整体重建，跟随开启时同样保持钉底。
         if (e.Action is not (NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Reset))
@@ -101,11 +57,27 @@ public partial class InstanceDashboardPage : Subpage
             return;
         }
 
-        if (_model?.IsAutoScroll == true)
+        if (IsAutoScroll)
         {
-            // 集合已变但 VirtualizingStackPanel 尚未重算 extent，同步 ScrollToEnd 会停在旧底部，故延后执行。
-            Dispatcher.UIThread.Post(LogScroller.ScrollToEnd);
+            RequestScrollToEnd();
         }
+    }
+
+    // 合并同一调度周期内的多次钉底请求：burst 新增只触发一次 ScrollToEnd，避免对每条日志都重排布局。
+    private void RequestScrollToEnd()
+    {
+        if (_scrollPending)
+        {
+            return;
+        }
+
+        _scrollPending = true;
+        // 集合已变但 VirtualizingStackPanel 尚未重算 extent，同步 ScrollToEnd 会停在旧底部，故延后执行。
+        Dispatcher.UIThread.Post(() =>
+        {
+            _scrollPending = false;
+            LogScroller.ScrollToEnd();
+        });
     }
 
     // NOTE: 用 OffsetDelta 的符号而非仅位置判断，是关键不直观点。
@@ -113,19 +85,24 @@ public partial class InstanceDashboardPage : Subpage
     //  若只看「是否在底部」会把这次事件误判为「离开底部」而错误关闭跟随，故仅在用户主动滚动（Delta 非零）时切换。
     private void OnLogScrollChanged(object? sender, ScrollChangedEventArgs e)
     {
-        if (_model == null)
-        {
-            return;
-        }
-
         var atBottom = LogScroller.Viewport.Height > 0 && LogScroller.Offset.Y >= LogScroller.ScrollBarMaximum.Y - 0.5d;
         if (e.OffsetDelta.Y < 0 && !atBottom)
         {
-            _model.IsAutoScroll = false;
+            _disableDebounce++;
+            // 连续多次向上滚才判定为有意回看，避免惯性/触控板抖动误关跟随
+            if (_disableDebounce > 3)
+            {
+                IsAutoScroll = false;
+                _disableDebounce = 0;
+            }
         }
-        else if (e.OffsetDelta.Y > 0 && atBottom)
+        else
         {
-            _model.IsAutoScroll = true;
+            _disableDebounce = 0;
+            if (e.OffsetDelta.Y > 0 && atBottom)
+            {
+                IsAutoScroll = true;
+            }
         }
     }
 }

--- a/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml.cs
+++ b/src/Polymerium.Avalonia/Pages/InstanceDashboardPage.axaml.cs
@@ -1,8 +1,132 @@
+using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using ObservableCollections;
 using Polymerium.Avalonia.Controls;
+using Polymerium.Avalonia.Models;
+using Polymerium.Avalonia.PageModels;
 
 namespace Polymerium.Avalonia.Pages;
 
 public partial class InstanceDashboardPage : Subpage
 {
-    public InstanceDashboardPage() => InitializeComponent();
+    private InstanceDashboardPageModel? _model;
+
+    // 当前正在订阅 CollectionChanged 的视图；FilteredLogCollection 会被重新赋值，
+    // 因此需要跟踪旧视图以便解绑，避免事件泄漏到已 Dispose 的视图上。
+    private NotifyCollectionChangedSynchronizedViewList<ScrapModel>? _subscribedView;
+
+    public InstanceDashboardPage()
+    {
+        InitializeComponent();
+        // DataContext 由 activator 在进入视觉树时设置，必须等它到达后才能挂到模型上。
+        DataContextChanged += OnDataContextChanged;
+        // 直接订阅日志 ScrollViewer 本身（而不是在页面级 AddHandler），
+        // 因为底部检测需要读取它的 Offset / ScrollBarMaximum。
+        LogScroller.ScrollChanged += OnLogScrollChanged;
+    }
+
+    // 每次导航都会由 activator 创建全新的页面与模型；DataContext 变化时解绑旧模型、挂上新模型。
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_model != null)
+        {
+            _model.PropertyChanged -= OnModelPropertyChanged;
+            _model = null;
+        }
+
+        Subscribe(null);
+
+        if (DataContext is InstanceDashboardPageModel model)
+        {
+            _model = model;
+            model.PropertyChanged += OnModelPropertyChanged;
+            Subscribe(model.FilteredLogCollection);
+        }
+    }
+
+    private void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // UpdateLogSource 会在切换日志源/启动/结束时重新赋值 FilteredLogCollection（旧视图已 Dispose），
+        // 这里必须跟着换绑 CollectionChanged，否则新视图的新增日志不会触发跟随滚动。
+        if (e.PropertyName == nameof(InstanceDashboardPageModel.FilteredLogCollection))
+        {
+            Subscribe(_model?.FilteredLogCollection);
+        }
+        // 用户点击切换按钮重新开启跟随时，无论当前在何处都应立刻跳到底部。
+        else if (e.PropertyName == nameof(InstanceDashboardPageModel.IsAutoScroll) && _model?.IsAutoScroll == true)
+        {
+            Dispatcher.UIThread.Post(LogScroller.ScrollToEnd);
+        }
+    }
+
+    private void Subscribe(NotifyCollectionChangedSynchronizedViewList<ScrapModel>? view)
+    {
+        if (_subscribedView == view)
+        {
+            return;
+        }
+
+        if (_subscribedView != null)
+        {
+            _subscribedView.CollectionChanged -= OnCollectionChanged;
+        }
+
+        _subscribedView = view;
+        if (view != null)
+        {
+            view.CollectionChanged += OnCollectionChanged;
+            // 视图刚就位时钉一次到底部：文件日志源是一次性整体载入的，可能不会再有 Add 事件，
+            // 而实时源在 OnInitializeAsync 挂载时缓冲可能已非空；Post 延迟到布局完成后执行。
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_model?.IsAutoScroll == true)
+                {
+                    LogScroller.ScrollToEnd();
+                }
+            });
+        }
+    }
+
+    private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // Reset 也触发跟随：过滤开关/搜索变化时视图会整体重建，跟随开启时应保持钉底；
+        // 环形缓冲满时淘汰头部也会以 Reset/Add 形式体现，与 toast 的既有行为保持一致。
+        if (e.Action is not (NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Reset))
+        {
+            return;
+        }
+
+        if (_model?.IsAutoScroll == true)
+        {
+            // Post 而非同步调用：集合已变化但 VirtualizingStackPanel 的 extent 尚未重新布局，
+            // 立即 ScrollToEnd 会停在旧的底部；延迟到消息队列尾部执行才能拿到最新 extent。
+            Dispatcher.UIThread.Post(LogScroller.ScrollToEnd);
+        }
+    }
+
+    // NOTE: 用 OffsetDelta 的符号而非仅位置判断，是关键不直观点——
+    // 跟随开启时新日志使 extent 增长，ScrollChanged 会因 extent 变化触发，但 OffsetDelta.Y 为 0；
+    // 若仅看"是否在底部"，该事件会误判为"离开底部"而关闭跟随。因此只在用户主动滚动（Delta 非零）时切换状态。
+    private void OnLogScrollChanged(object? sender, ScrollChangedEventArgs e)
+    {
+        if (_model == null)
+        {
+            return;
+        }
+
+        var atBottom = LogScroller.Viewport.Height > 0 && LogScroller.Offset.Y >= LogScroller.ScrollBarMaximum.Y - 0.5d;
+        if (e.OffsetDelta.Y < 0 && !atBottom)
+        {
+            // 用户向上滚动离开底部：说明在回看历史日志，停止跟随（按钮随之取消勾选）。
+            _model.IsAutoScroll = false;
+        }
+        else if (e.OffsetDelta.Y > 0 && atBottom)
+        {
+            // 用户主动滚回到底部：恢复跟随，对应"滚动条在最下方时持续滚动到最新日志"。
+            _model.IsAutoScroll = true;
+        }
+    }
 }

--- a/src/Polymerium.Avalonia/Properties/Resources.Designer.cs
+++ b/src/Polymerium.Avalonia/Properties/Resources.Designer.cs
@@ -6705,6 +6705,12 @@ namespace Polymerium.Avalonia.Properties {
             }
         }
         
+        public static string InstanceDashboardPage_AutoScrollToolTipText {
+            get {
+                return ResourceManager.GetString("InstanceDashboardPage_AutoScrollToolTipText", resourceCulture);
+            }
+        }
+        
         public static string InstancePage_ImportAssetToolTipText {
             get {
                 return ResourceManager.GetString("InstancePage_ImportAssetToolTipText", resourceCulture);

--- a/src/Polymerium.Avalonia/Properties/Resources.resx
+++ b/src/Polymerium.Avalonia/Properties/Resources.resx
@@ -3372,6 +3372,9 @@ Affected entries: {0}
     <data name="InstanceDashboardPage_FilterErrorText" xml:space="preserve">
         <value>Error</value>
     </data>
+    <data name="InstanceDashboardPage_AutoScrollToolTipText" xml:space="preserve">
+        <value>Auto-scroll to latest log</value>
+    </data>
     <data name="InstancePage_ImportAssetToolTipText" xml:space="preserve">
         <value>Import asset from file</value>
     </data>

--- a/src/Polymerium.Avalonia/Properties/Resources.zh-hans.resx
+++ b/src/Polymerium.Avalonia/Properties/Resources.zh-hans.resx
@@ -3363,6 +3363,9 @@
     <data name="InstanceDashboardPage_FilterErrorText" xml:space="preserve">
         <value>错误</value>
     </data>
+    <data name="InstanceDashboardPage_AutoScrollToolTipText" xml:space="preserve">
+        <value>自动滚动到最新日志</value>
+    </data>
     <data name="InstancePage_ImportAssetToolTipText" xml:space="preserve">
         <value>从文件导入资源</value>
     </data>


### PR DESCRIPTION
- Add an auto-scroll toggle, enabled by default, that pins the log scroller to the bottom while new lines arrive
- Stop following when the user scrolls up from the bottom and resume it when scrolled back down
- Scroll to the end immediately when follow is re-enabled through the toggle or the scroller
- Track and re-subscribe FilteredLogCollection as it is re-assigned on log source changes
- Add English and Chinese tooltip text for the toggle